### PR TITLE
Allow instances to set settings as kwargs

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,14 +1,4 @@
 services:
-
-  dremio:
-    image: dremio/dremio-oss:latest
-    ports:
-      - 9047:9047
-      - 31010:31010
-      - 32010:32010
-    environment:
-      - DREMIO_JAVA_SERVER_EXTRA_OPTS=-Dpaths.dist=file:///opt/dremio/data/dist
-    container_name: dremio
   nessie:
     image: ghcr.io/projectnessie/nessie:0.104.1
     container_name: nessie
@@ -25,6 +15,7 @@ services:
       - nessie.catalog.secrets.access-key.name=admin
       - nessie.catalog.secrets.access-key.secret=password
       - nessie.catalog.service.s3.default-options.region=us-east-1
+      # auth bits
       - nessie.server.authentication.enabled=true
       - quarkus.oidc.auth-server-url=https://login.microsoftonline.com/${LOCKNESSIE_OPENID_TENANT}/v2.0
       - quarkus.oidc.client-id=${LOCKNESSIE_OPENID_CLIENT_ID}

--- a/src/locknessie/main.py
+++ b/src/locknessie/main.py
@@ -1,18 +1,22 @@
+from typing import TYPE_CHECKING
 from locknessie.settings import safely_get_settings, OpenIDIssuer
 from typing import Optional
 from locknessie.auth_providers.base import AuthType
 
-settings = safely_get_settings()
+if TYPE_CHECKING:
+    from locknessie.settings import ConfigSettings
 
 class LockNessie:
+    settings: "ConfigSettings"
 
-    def __init__(self, auth_type: Optional[str] = AuthType.user):
+    def __init__(self, auth_type: Optional[str] = AuthType.user, **kwargs):
         """set the correct provider based on the settings"""
-        self.provider = self._get_provider(auth_type="user")
+        self.settings = safely_get_settings(**kwargs)
+        self.provider = self._get_provider(auth_type=auth_type)
 
     def _get_provider(self, auth_type: str) -> str:
         """returns the correct provider based on the settings"""
-        match settings.openid_issuer:
+        match self.settings.openid_issuer:
             case OpenIDIssuer.microsoft:
                 from locknessie.auth_providers.microsoft import MicrosoftAuth
                 return MicrosoftAuth(auth_type=auth_type)


### PR DESCRIPTION
It is natural (and makes sense) to be able to pass kwargs to the instance on creation like this: 

```python

auth = LockNessie(openid_client_id="xxxxxxxx", openid_client_secret="yyyyyyy", auth_type="daemon")
auth.get_token()
```

so now, with this PR, you can. 