### PR TITLE
Automatically restrict tenants unless all is specified

### DIFF
--- a/src/locknessie/auth_providers/microsoft.py
+++ b/src/locknessie/auth_providers/microsoft.py
@@ -67,8 +67,12 @@ class MicrosoftAuth(AuthBase):
                     authority=f"https://login.microsoftonline.com/{settings.openid_tenant}"
                 )
             case AuthType.user:
+                extra_args = {}
+                if not settings.openid_allow_all_tenants:
+                    extra_args["authority"] = f"https://login.microsoftonline.com/{settings.openid_tenant}"
                 return msal.PublicClientApplication(client_id=settings.openid_client_id,
-                                                    token_cache=cache)
+                                                    token_cache=cache,
+                                                    **extra_args)
             case _:
                 raise ValueError(f"Invalid auth type: {self.auth_type}")
 

--- a/tests/test_get_token.py
+++ b/tests/test_get_token.py
@@ -17,7 +17,7 @@ class TestProviders:
 
     @m.parametrize(
         "patched_settings_file",
-        [("microsoft", "user")],
+        [("microsoft", "user", {"openid_allow_all_tenants": True})],
         indirect=True
     )
     @m.context("and the user flow is selected")


### PR DESCRIPTION
In most cases, you'll want to restrict access to people within your tenant (i.e. only people with hamburger.com logins can access the hamburger.com data lake). 

For Microsoft that option requires an authority on the public auth. This PR adds the authority spec to the public auth application instantiation. 

