### PR TITLE
move settings to dependency injection

### DIFF
--- a/src/locknessie/auth_providers/base.py
+++ b/src/locknessie/auth_providers/base.py
@@ -1,6 +1,9 @@
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from locknessie.settings import ConfigSettings
 
 class AuthType(str, Enum):
     user = "user"
@@ -9,9 +12,12 @@ class AuthType(str, Enum):
 
 class AuthBase(ABC):
     _auth_type: AuthType
+    settings: "ConfigSettings"
 
-    def __init__(self, auth_type: Optional[AuthType] = AuthType.user):
+    def __init__(self, settings: "ConfigSettings",
+                 auth_type: Optional[AuthType] = AuthType.user):
         self._auth_type = auth_type
+        self.settings = settings
 
     @property
     def auth_type(self) -> AuthType:

--- a/src/locknessie/auth_providers/base.py
+++ b/src/locknessie/auth_providers/base.py
@@ -14,7 +14,8 @@ class AuthBase(ABC):
     _auth_type: AuthType
     settings: "ConfigSettings"
 
-    def __init__(self, settings: "ConfigSettings",
+    def __init__(self,
+                 settings: "ConfigSettings",
                  auth_type: Optional[AuthType] = AuthType.user):
         self._auth_type = auth_type
         self.settings = settings

--- a/src/locknessie/auth_providers/microsoft.py
+++ b/src/locknessie/auth_providers/microsoft.py
@@ -23,7 +23,7 @@ class MicrosoftAuth(AuthBase):
         """
         auth_type: the type of authentication to use - users can log in with a browser, daemons can use secret credentials.
         """
-        super().__init__(auth_type, settings)
+        super().__init__(settings=settings, auth_type=auth_type)
         self.cache = None
         if self.auth_type == AuthType.user:
             self.scopes = ["User.Read"]

--- a/src/locknessie/auth_providers/microsoft.py
+++ b/src/locknessie/auth_providers/microsoft.py
@@ -1,13 +1,11 @@
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Optional, TYPE_CHECKING
 import msal
 from locknessie.logger import get_logger
-from locknessie.settings import safely_get_settings
 from locknessie.auth_providers.base import AuthBase, AuthType
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-settings = safely_get_settings()
+    from locknessie.settings import ConfigSettings
 
 logger = get_logger(__name__)
 
@@ -20,11 +18,12 @@ class MicrosoftAuth(AuthBase):
     cache: "msal.SerializableTokenCache"
 
     def __init__(self,
+                 settings: "ConfigSettings",
                  auth_type: Optional[AuthType] = AuthType.user):
         """
         auth_type: the type of authentication to use - users can log in with a browser, daemons can use secret credentials.
         """
-        super().__init__(auth_type)
+        super().__init__(auth_type, settings)
         self.cache = None
         if self.auth_type == AuthType.user:
             self.scopes = ["User.Read"]
@@ -44,7 +43,7 @@ class MicrosoftAuth(AuthBase):
         return self._get_token()
 
     def initilaize_cache_file(self, cache_file_name: str) -> "Path":
-        cache_file = settings.config_dir / cache_file_name
+        cache_file = self.settings.config_dir / cache_file_name
         cache_file.parent.mkdir(parents=True, exist_ok=True)
         return cache_file
 
@@ -62,15 +61,15 @@ class MicrosoftAuth(AuthBase):
         match self.auth_type:
             case AuthType.daemon:
                 return msal.ConfidentialClientApplication(
-                    client_id=settings.openid_client_id,
-                    client_credential=settings.openid_secret,
-                    authority=f"https://login.microsoftonline.com/{settings.openid_tenant}"
+                    client_id=self.settings.openid_client_id,
+                    client_credential=self.settings.openid_secret,
+                    authority=f"https://login.microsoftonline.com/{self.settings.openid_tenant}"
                 )
             case AuthType.user:
                 extra_args = {}
-                if not settings.openid_allow_all_tenants:
-                    extra_args["authority"] = f"https://login.microsoftonline.com/{settings.openid_tenant}"
-                return msal.PublicClientApplication(client_id=settings.openid_client_id,
+                if not self.settings.openid_allow_all_tenants:
+                    extra_args["authority"] = f"https://login.microsoftonline.com/{self.settings.openid_tenant}"
+                return msal.PublicClientApplication(client_id=self.settings.openid_client_id,
                                                     token_cache=cache,
                                                     **extra_args)
             case _:

--- a/src/locknessie/main.py
+++ b/src/locknessie/main.py
@@ -19,7 +19,7 @@ class LockNessie:
         match self.settings.openid_issuer:
             case OpenIDIssuer.microsoft:
                 from locknessie.auth_providers.microsoft import MicrosoftAuth
-                return MicrosoftAuth(auth_type=auth_type)
+                return MicrosoftAuth(auth_type=auth_type, settings=self.settings)
             case _:
                 raise NotImplementedError("Not implemented")
 


### PR DESCRIPTION
This way all the settings can be set/overridden in `LockNessie()` so it is easy to be explicit.